### PR TITLE
Feature/deferrable delegator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,17 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
-## 1.0.0 - 2019-01-14
+## 1.1.0 - TBD
 
 ### Added
 
 - [#1](https://github.com/phly/phly-swoole-taskworker/pull/1) adds the class `DeferredListener`; it operates identically to `QueuedListener`,
   and replaces its functionality, albeit with a more accurate name.
 
-- All functionality.
+- [#2](https://github.com/phly/phly-swoole-taskworker/pull/2) adds the delegator factory `Phly\Swoole\TaskWorker\DeferredListenerDelegator`.
+  This factory can be attached to any listener service in order to allow it to
+  be deferred when invoked. I suggest doing so in `config/autoload/local.php` to
+  allow testing the listener in development, but deferring it in production.
 
 ### Changed
 
@@ -19,6 +22,28 @@ All notable changes to this project will be documented in this file, in reverse 
 
 - [#1](https://github.com/phly/phly-swoole-taskworker/pull/1) deprecates the `QueueableListener` class in favor of the new
   `DeferredListener` class.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- Nothing.
+
+## 1.0.0 - 2019-01-14
+
+### Added
+
+- All functionality.
+
+### Changed
+
+- Nothing.
+
+### Deprecated
+
+- Nothing.
 
 ### Removed
 

--- a/docs/book/deferred-listeners.md
+++ b/docs/book/deferred-listeners.md
@@ -2,6 +2,8 @@
 
 > Formerly "Queued Listeners".
 
+- Since 1.1.0
+
 When using a [PSR-14](https://github.com/php-fig/fig-standards/blob/bb8df27dba53fa5cbc653d1d446f850e5690f3cc/proposed/event-dispatcher.md)
 event dispatcher, you may want to defer the work of a listener instead of
 handling it immediately. As an example, if you have a listener that might be
@@ -31,4 +33,34 @@ $listener = new DeferredListener(
 
 // Assuming a provider with an "attach()" method:
 $provider->attach(SomeEvent::class, $listener);
+```
+
+## DeferredListenerDelegator
+
+To help automate deferment, you can use [delegator factories](https://docs.zendframework.com/zend-expressive/v3/features/container/delegator-factories/).
+This package provides a delegator via the class
+`Phly\Swoole\TaskWorker\DeferredListenerDelegator`.
+
+In typical usage, you will assign this to individual listener services within
+your `config/autoload/local.php` file in production, so that deferment only
+happens in production.
+
+As an example:
+
+```php
+// in config/autoload/local.php
+use Phly\Swoole\TaskWorker\DeferredListenerDelegator;
+
+return [
+    'dependencies' => [
+        'factories' => [
+            App\SomeEventListener::class => App\SomeEventListenerFactory::class
+        ],
+        'delegators' => [
+            App\SomeEventListener::class => [
+                DeferredListenerDelegator::class,
+            ],
+        ],
+    ],
+];
 ```

--- a/src/DeferredListenerDelegator.php
+++ b/src/DeferredListenerDelegator.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * @see       https://github.com/phly/phly-swoole-taskworker for the canonical source repository
+ * @copyright Copyright (c) 2019 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/phly/phly-swoole-taskworker/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Phly\Swoole\TaskWorker;
+
+use Psr\Container\ContainerInterface;
+use Swoole\Http\Server as HttpServer;
+
+class DeferredListenerDelegator
+{
+    /**
+     * Decorate a listener as a DeferredListener
+     *
+     * If the $factory does not produce a PHP callable, this method
+     * returns it verbatim. Otherwise, it decorates it as a DeferredListener.
+     *
+     * @return DeferredListener|mixed
+     */
+    public function __invoke(
+        ContainerInterface $container,
+        string $serviceName,
+        callable $factory
+    ) {
+        $listener = $factory();
+        if (! is_callable($listener)) {
+            return $listener;
+        }
+
+        return new DeferredListener(
+            $container->get(HttpServer::class),
+            $listener
+        );
+    }
+}

--- a/test/DeferredListenerDelegatorTest.php
+++ b/test/DeferredListenerDelegatorTest.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * @see       https://github.com/phly/phly-swoole-taskworker for the canonical source repository
+ * @copyright Copyright (c) 2019 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/phly/phly-swoole-taskworker/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Phlytest\Swoole\TaskWorker;
+
+use Phly\Swoole\TaskWorker\DeferredListener;
+use Phly\Swoole\TaskWorker\DeferredListenerDelegator;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Swoole\Http\Server as HttpServer;
+use stdClass;
+
+class DeferredListenerDelegatorTest extends TestCase
+{
+    public function setUp()
+    {
+        $this->server = $this->createMock(HttpServer::class);
+        $this->container = $this->prophesize(ContainerInterface::class);
+    }
+
+    public function testReturnsOriginalServiceIfNotCallable()
+    {
+        $instance = new stdClass();
+        $factory = function () use ($instance) {
+            return $instance;
+        };
+
+        $delegator = new DeferredListenerDelegator();
+
+        $this->assertSame($instance, $delegator(
+            $this->container->reveal(),
+            'listener',
+            $factory
+        ));
+        $this->container->get(HttpServer::class)->shouldNotHaveBeenCalled();
+    }
+
+    public function testReturnsDecoratedListenerWhenOriginalServiceIsCallable()
+    {
+        $listener = function ($event) {
+        };
+        $factory = function () use ($listener) {
+            return $listener;
+        };
+        $this->container->get(HttpServer::class)->willReturn($this->server);
+
+        $delegator = new DeferredListenerDelegator();
+
+        $instance = $delegator(
+            $this->container->reveal(),
+            'listener',
+            $factory
+        );
+
+        $this->assertNotSame($listener, $instance);
+        $this->container->get(HttpServer::class)->shouldHaveBeenCalled();
+        $this->assertAttributeSame($this->server, 'server', $instance);
+        $this->assertAttributeSame($listener, 'listener', $instance);
+    }
+}

--- a/test/DeferredListenerTest.php
+++ b/test/DeferredListenerTest.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * @license http://opensource.org/licenses/BSD-2-Clause BSD-2-Clause
+ * @copyright Copyright (c) Matthew Weier O'Phinney
+ */
+
+declare(strict_types=1);
+
+namespace PhlyTest\Swoole\TaskWorker;
+
+use Phly\Swoole\TaskWorker\DeferredListener;
+use Phly\Swoole\TaskWorker\Task;
+use PHPUnit\Framework\TestCase;
+use ReflectionProperty;
+use Swoole\Http\Server as HttpServer;
+
+class DeferredListenerTest extends TestCase
+{
+    public function testListenerInvocationCreatesAServerTaskWithTheListenerAndEvent()
+    {
+        $listener = function () {
+        };
+        $event = (object) ['event' => true];
+
+        $server = $this->createMock(HttpServer::class);
+        $server
+            ->expects($this->once())
+            ->method('task')
+            ->with($this->callback(function ($task) use ($listener, $event) {
+                if (! $task instanceof Task) {
+                    return false;
+                }
+
+                $r = new ReflectionProperty($task, 'handler');
+                $r->setAccessible(true);
+                if ($listener !== $r->getValue($task)) {
+                    return false;
+                }
+
+                $r = new ReflectionProperty($task, 'payload');
+                $r->setAccessible(true);
+                if ([$event] !== $r->getValue($task)) {
+                    return false;
+                }
+
+                return true;
+            }));
+
+        $deferredListener = new DeferredListener($server, $listener);
+
+        $this->assertNull($deferredListener($event));
+    }
+}


### PR DESCRIPTION
Adds a `DeferredListenerDelegator` delegator factory implementation that can be attached to individual listener services in order to allow them to be deferred.