### PR TITLE
feat: service-based deferred listeners

### DIFF
--- a/docs/book/deferred-listeners.md
+++ b/docs/book/deferred-listeners.md
@@ -3,6 +3,7 @@
 > Formerly "Queued Listeners".
 
 - Since 1.1.0
+- DeferredServiceListener and DeferredServiceListenerDelegator since 2.0.0
 
 When using a [PSR-14](https://github.com/php-fig/fig-standards/blob/bb8df27dba53fa5cbc653d1d446f850e5690f3cc/proposed/event-dispatcher.md)
 event dispatcher, you may want to defer the work of a listener instead of
@@ -10,7 +11,7 @@ handling it immediately. As an example, if you have a listener that might be
 updating statistics, but this is not time-critical, you could benefit from
 deferring the calculations.
 
-This package defines a "deferred listener" for this purpose. It will decorate an
+This package defines "deferred listeners" for this purpose. It will decorate an
 existing listener, and, when invoked, create a Swoole task.
 
 ## DeferredListener
@@ -28,12 +29,19 @@ use Phly\Swoole\TaskWorker\DeferredListener;
 // @var Swoole\Http\Server $server
 $listener = new DeferredListener(
     $server,
-    new SomeListenerImplementingShouldQueue()
+    'functionToHandleTask'
 );
 
 // Assuming a provider with an "attach()" method:
 $provider->attach(SomeEvent::class, $listener);
 ```
+
+> ### Serializable Listeners only
+>
+> Listeners decorated in a `DeferredListener` must be serializable. This
+> essentially excludes any class-based listeners that have dependencies. If you
+> plan to use such a listener, skip ahead below to the [section on deferred
+> service listeners](#deferredservicelistener).
 
 ## DeferredListenerDelegator
 
@@ -64,3 +72,75 @@ return [
     ],
 ];
 ```
+
+> ### Serializable Listeners only
+>
+> Listeners decorated via the delegator MUST be serializable, which
+> essentially excludes any class-based listeners that have dependencies. If you
+> plan to use such a listener, continue reading.
+
+## DeferredServiceListener
+
+- Since 2.0.0
+
+Swoole only allows passing tasks that are serializable. Since most listeners
+used to create Swoole tasks will likely have one or more dependencies (e.g., an
+HTTP client, a database adapter, etc.), this can pose a problem if you want to
+defer a listener to execute via a task worker.
+
+To resolve that issue, we offer `Phly\Swoole\TaskWorker\DeferredServiceListener`. 
+This class accepts the following constructor arguments:
+
+- The Swoole HTTP server instance.
+- The callable listener that you want to use for processing.
+- The service name used to fetch the listener from the PSR-11 DI container.
+
+As an example:
+
+```php
+use Phly\Swoole\TaskWorker\DeferredListener;
+
+// @var Swoole\Http\Server $server
+$listener = new DeferredListener(
+    $server,
+    $actualListener,
+    $actualListener::class // assuming it is registered using the class name
+);
+
+// Assuming a provider with an "attach()" method:
+$provider->attach(SomeEvent::class, $listener);
+```
+
+## DeferredServiceListenerDelegator
+
+- Since 2.0.0
+
+Just as with the [DeferredListenerDelegator](#deferredlistenerdelegator), we
+provide `Phly\Swoole\TaskWorker\DeferredServiceListenerDelegator` to automate
+decorating a listener registered in the container as a `DeferredServiceListener`.
+
+In typical usage, you will assign this to individual listener services within
+your `config/autoload/local.php` file in production, so that deferment only
+happens in production.
+
+As an example:
+
+```php
+// in config/autoload/local.php
+use Phly\Swoole\TaskWorker\DeferredServiceListenerDelegator;
+
+return [
+    'dependencies' => [
+        'factories' => [
+            App\SomeEventListener::class => App\SomeEventListenerFactory::class
+        ],
+        'delegators' => [
+            App\SomeEventListener::class => [
+                DeferredServiceListenerDelegator::class,
+            ],
+        ],
+    ],
+];
+```
+
+This is the RECOMMENDED way to defer listeners for use with the task worker.

--- a/docs/book/intro.md
+++ b/docs/book/intro.md
@@ -6,7 +6,7 @@ This component provides a task worker implementation for
 The task runner expects `Phly\Swoole\TaskWorker\TaskInterface` instances as the
 payload to process. `TaskInterface` instances must:
 
-- Define `__invoke()`, which should not return any values.
+- Define `__invoke(\Psr\Container\ContainerInterface) :void`.
 - Implement `JsonSerializable`'s `jsonSerialize()` method (`TaskInterface`
   extends this interface). This latter is used by the task worker to log the
   task being handled.

--- a/src/DeferredServiceListener.php
+++ b/src/DeferredServiceListener.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * @license http://opensource.org/licenses/BSD-2-Clause BSD-2-Clause
+ * @copyright Copyright (c) Matthew Weier O'Phinney
+ */
+
+declare(strict_types=1);
+
+namespace Phly\Swoole\TaskWorker;
+
+use Swoole\Http\Server as HttpServer;
+
+/**
+ * Decorator for an event listener that defers it to run as a Swoole task.
+ *
+ * When invoked, this listener will create a Task instance with the
+ * provided event and the decorated listener, and pass it to the composed
+ * HTTP server's task method.
+ */
+final class DeferredServiceListener
+{
+    /**
+     * @var HttpServer
+     */
+    private $server;
+
+    /**
+     * @var callable
+     */
+    private $listener;
+
+    /**
+     * @var string
+     */
+    private $serviceName;
+
+    public function __construct(HttpServer $server, callable $listener, string $serviceName)
+    {
+        $this->server      = $server;
+        $this->listener    = $listener;
+        $this->serviceName = $serviceName;
+    }
+
+    public function __invoke(object $event) : void
+    {
+        $this->server->task(new ServiceBasedTask($this->serviceName, $event));
+    }
+
+    public function getListener(): callable
+    {
+        return $this->listener;
+    }
+}

--- a/src/DeferredServiceListenerDelegator.php
+++ b/src/DeferredServiceListenerDelegator.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * @see       https://github.com/phly/phly-swoole-taskworker for the canonical source repository
+ * @copyright Copyright (c) 2019 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/phly/phly-swoole-taskworker/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Phly\Swoole\TaskWorker;
+
+use Psr\Container\ContainerInterface;
+use Swoole\Http\Server as HttpServer;
+
+class DeferredServiceListenerDelegator
+{
+    /**
+     * Decorate a listener as a DeferredListener
+     *
+     * If the $factory does not produce a PHP callable, this method
+     * returns it verbatim. Otherwise, it decorates it as a DeferredListener.
+     *
+     * @return DeferredServiceListener|mixed
+     */
+    public function __invoke(
+        ContainerInterface $container,
+        string $serviceName,
+        callable $factory
+    ) {
+        $listener = $factory();
+        if (! is_callable($listener)) {
+            return $listener;
+        }
+
+        return new DeferredServiceListener(
+            $container->get(HttpServer::class),
+            $listener,
+            $serviceName
+        );
+    }
+}

--- a/src/ServiceBasedTask.php
+++ b/src/ServiceBasedTask.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * @license http://opensource.org/licenses/BSD-2-Clause BSD-2-Clause
+ * @copyright Copyright (c) Matthew Weier O'Phinney
+ */
+
+declare(strict_types=1);
+
+namespace Phly\Swoole\TaskWorker;
+
+use Psr\Container\ContainerInterface;
+
+/**
+ * Representation of a task to execute via task worker.
+ *
+ * Contains the callable that will handle the task, and an array of arguments
+ * with which to call it. Handlers are expected to return void; any return
+ * values will be ignored.
+ */
+final class ServiceBasedTask implements TaskInterface
+{
+    /**
+     * @var array
+     */
+    private $payload;
+
+    /**
+     * @var string
+     */
+    private $serviceName;
+
+    public function __construct(string $serviceName, ...$payload)
+    {
+        $this->serviceName = $serviceName;
+        $this->payload     = $payload;
+    }
+
+    public function __invoke(ContainerInterface $container) : void
+    {
+        $deferred = $container->get($this->serviceName);
+        $listener = $deferred instanceof DeferredServiceListener
+            ? $deferred->getListener()
+            : $deferred;
+        $listener(...$this->payload);
+    }
+
+    public function jsonSerialize()
+    {
+        return [
+            'handler'   => $this->serviceName,
+            'arguments' => $this->payload,
+        ];
+    }
+}

--- a/src/Task.php
+++ b/src/Task.php
@@ -8,6 +8,8 @@ declare(strict_types=1);
 
 namespace Phly\Swoole\TaskWorker;
 
+use Psr\Container\ContainerInterface;
+
 /**
  * Representation of a task to execute via task worker.
  *
@@ -33,7 +35,7 @@ final class Task implements TaskInterface
         $this->payload = $payload;
     }
 
-    public function __invoke() : void
+    public function __invoke(ContainerInterface $container) : void
     {
         ($this->handler)(...$this->payload);
     }

--- a/src/TaskInterface.php
+++ b/src/TaskInterface.php
@@ -9,11 +9,12 @@ declare(strict_types=1);
 namespace Phly\Swoole\TaskWorker;
 
 use JsonSerializable;
+use Psr\Container\ContainerInterface;
 
 interface TaskInterface extends JsonSerializable
 {
     /**
      * Tasks are invokable; implement this method to do the work of the task.
      */
-    public function __invoke() : void;
+    public function __invoke(ContainerInterface $container) : void;
 }

--- a/src/TaskWorker.php
+++ b/src/TaskWorker.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace Phly\Swoole\TaskWorker;
 
+use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use Swoole\Http\Server as HttpServer;
 use Throwable;
@@ -17,9 +18,10 @@ class TaskWorker
     /** @var LoggerInterface */
     private $logger;
 
-    public function __construct(LoggerInterface $logger)
+    public function __construct(ContainerInterface $container, LoggerInterface $logger)
     {
-        $this->logger = $logger;
+        $this->container = $container;
+        $this->logger    = $logger;
     }
 
     public function __invoke(HttpServer $server, int $taskId, int $fromId, $task) : void
@@ -41,7 +43,7 @@ class TaskWorker
         );
 
         try {
-            $task();
+            $task($this->container);
         } catch (Throwable $e) {
             $this->logNotifierException($e, $taskId);
         } finally {

--- a/src/TaskWorkerFactory.php
+++ b/src/TaskWorkerFactory.php
@@ -16,6 +16,7 @@ class TaskWorkerFactory
     public function __invoke(ContainerInterface $container) : TaskWorker
     {
         return new TaskWorker(
+            $container,
             $container->get(LoggerInterface::class)
         );
     }

--- a/test/DeferredServiceListenerDelegatorTest.php
+++ b/test/DeferredServiceListenerDelegatorTest.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * @see       https://github.com/phly/phly-swoole-taskworker for the canonical source repository
+ * @copyright Copyright (c) 2019 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/phly/phly-swoole-taskworker/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Phlytest\Swoole\TaskWorker;
+
+use Phly\Swoole\TaskWorker\DeferredServiceListener;
+use Phly\Swoole\TaskWorker\DeferredServiceListenerDelegator;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Swoole\Http\Server as HttpServer;
+use stdClass;
+
+class DeferredServiceListenerDelegatorTest extends TestCase
+{
+    public function setUp()
+    {
+        $this->server    = $this->createMock(HttpServer::class);
+        $this->container = $this->prophesize(ContainerInterface::class);
+    }
+
+    public function testReturnsOriginalServiceIfNotCallable()
+    {
+        $instance = new stdClass();
+        $factory = function () use ($instance) {
+            return $instance;
+        };
+
+        $delegator = new DeferredServiceListenerDelegator();
+
+        $this->assertSame($instance, $delegator(
+            $this->container->reveal(),
+            'listener',
+            $factory
+        ));
+        $this->container->get(HttpServer::class)->shouldNotHaveBeenCalled();
+    }
+
+    public function testReturnsDecoratedListenerWhenOriginalServiceIsCallable()
+    {
+        $listener = function ($event) {
+        };
+        $factory = function () use ($listener) {
+            return $listener;
+        };
+        $this->container->get(HttpServer::class)->willReturn($this->server);
+
+        $delegator = new DeferredServiceListenerDelegator();
+
+        $instance = $delegator(
+            $this->container->reveal(),
+            'listener',
+            $factory
+        );
+
+        $this->assertNotSame($listener, $instance);
+        $this->assertInstanceOf(DeferredServiceListener::class, $instance);
+        $this->assertAttributeSame($this->server, 'server', $instance);
+        $this->assertAttributeSame('listener', 'serviceName', $instance);
+        $this->assertSame($listener, $instance->getListener());
+    }
+}

--- a/test/DeferredServiceListenerTest.php
+++ b/test/DeferredServiceListenerTest.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * @license http://opensource.org/licenses/BSD-2-Clause BSD-2-Clause
+ * @copyright Copyright (c) Matthew Weier O'Phinney
+ */
+
+declare(strict_types=1);
+
+namespace PhlyTest\Swoole\TaskWorker;
+
+use Phly\Swoole\TaskWorker\DeferredServiceListener;
+use Phly\Swoole\TaskWorker\ServiceBasedTask;
+use PHPUnit\Framework\TestCase;
+use ReflectionProperty;
+use Swoole\Http\Server as HttpServer;
+
+class DeferredServiceListenerTest extends TestCase
+{
+    public function testListenerInvocationCreatesAServerBasedTaskWithTheListenerNameAndEvent()
+    {
+        $listener = function () {
+        };
+        $event = (object) ['event' => true];
+
+        $server = $this->createMock(HttpServer::class);
+        $server
+            ->expects($this->once())
+            ->method('task')
+            ->with($this->callback(function ($task) use ($event) {
+                if (! $task instanceof ServiceBasedTask) {
+                    return false;
+                }
+
+                $r = new ReflectionProperty($task, 'serviceName');
+                $r->setAccessible(true);
+                if ($r->getValue($task) !== 'service-name') {
+                    return false;
+                }
+
+                $r = new ReflectionProperty($task, 'payload');
+                $r->setAccessible(true);
+                if ([$event] !== $r->getValue($task)) {
+                    return false;
+                }
+
+                return true;
+            }));
+
+        $deferredListener = new DeferredServiceListener($server, $listener, 'service-name');
+
+        $this->assertSame($listener, $deferredListener->getListener());
+        $this->assertNull($deferredListener($event));
+    }
+}

--- a/test/ServiceBasedTaskTest.php
+++ b/test/ServiceBasedTaskTest.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * @license http://opensource.org/licenses/BSD-2-Clause BSD-2-Clause
+ * @copyright Copyright (c) Matthew Weier O'Phinney
+ */
+
+declare(strict_types=1);
+
+namespace PhlyTest\Swoole\TaskWorker;
+
+use Phly\Swoole\TaskWorker\DeferredServiceListener;
+use Phly\Swoole\TaskWorker\ServiceBasedTask;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Swoole\Http\Server as HttpServer;
+
+class ServiceBasedTaskTest extends TestCase
+{
+    public function setUp()
+    {
+        $this->container = $this->prophesize(ContainerInterface::class);
+        $this->handler   = 'service-name';
+        $this->task      = new ServiceBasedTask($this->handler, 'first', 'second');
+    }
+
+    public function testTaskIsInvokableAndCallsServiceDirectlyIfNotADeferredServiceListener()
+    {
+        $spy = (object) ['payload' => null];
+        $this->container->get($this->handler)->willReturn(function (...$args) use ($spy) {
+            $spy->payload = $args;
+        });
+
+        ($this->task)($this->container->reveal());
+
+        $this->assertSame([
+            'first',
+            'second',
+        ], $spy->payload);
+    }
+
+    public function testTaskIsInvokableAndCallsListenerComposedInDeferredServiceListener()
+    {
+        $spy      = (object) ['payload' => null];
+        $server   = $this->createMock(HttpServer::class);
+        $deferred = new DeferredServiceListener($server, function (...$args) use ($spy) {
+            $spy->payload = $args;
+        }, $this->handler);
+        $this->container->get($this->handler)->willReturn($deferred);
+
+        ($this->task)($this->container->reveal());
+
+        $this->assertSame([
+            'first',
+            'second',
+        ], $spy->payload);
+    }
+
+    public function testTaskIsSerializable()
+    {
+        $expected = [
+            'handler'   => $this->handler,
+            'arguments' => [
+                'first',
+                'second',
+            ],
+        ];
+
+        $this->assertSame($expected, $this->task->jsonSerialize());
+    }
+}

--- a/test/TaskTest.php
+++ b/test/TaskTest.php
@@ -11,12 +11,14 @@ namespace PhlyTest\Swoole\TaskWorker;
 use Closure;
 use Phly\Swoole\TaskWorker\Task;
 use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
 
 class TaskTest extends TestCase
 {
     public function setUp()
     {
-        $this->result = (object) ['payload' => null];
+        $this->container = $this->prophesize(ContainerInterface::class)->reveal();
+        $this->result    = (object) ['payload' => null];
 
         $this->handler = function ($a, $b) {
             $this->result->payload = [
@@ -30,7 +32,7 @@ class TaskTest extends TestCase
 
     public function testTaskIsInvokable()
     {
-        ($this->task)();
+        ($this->task)($this->container);
 
         $this->assertSame([
             'a' => 'first',

--- a/test/TaskWorkerTest.php
+++ b/test/TaskWorkerTest.php
@@ -13,18 +13,19 @@ use Phly\Swoole\TaskWorker\TaskWorker;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
 use Swoole\Http\Server as HttpServer;
-use Throwable;
 
 class TaskWorkerTest extends TestCase
 {
     public function setUp()
     {
-        $this->server = $this->createMock(HttpServer::class);
-        $this->logger = $this->prophesize(LoggerInterface::class);
-        $this->taskWorker = new TaskWorker($this->logger->reveal());
+        $this->container  = $this->prophesize(ContainerInterface::class);
+        $this->server     = $this->createMock(HttpServer::class);
+        $this->logger     = $this->prophesize(LoggerInterface::class);
+        $this->taskWorker = new TaskWorker($this->container->reveal(), $this->logger->reveal());
     }
 
     public function testLogsErrorWhenTaskIsNotATask()
@@ -64,7 +65,7 @@ class TaskWorkerTest extends TestCase
         $spy = (object) ['triggered' => false];
         $task = $this->prophesize(TaskInterface::class);
         $task->
-            __invoke()
+            __invoke($this->container->reveal())
             ->will(function () use ($spy) {
                 $spy->triggered = true;
             });
@@ -102,7 +103,7 @@ class TaskWorkerTest extends TestCase
 
         $task = $this->prophesize(TaskInterface::class);
         $task->
-            __invoke()
+            __invoke($this->container->reveal())
             ->will(function () use ($throwable) {
                 throw $throwable;
             });


### PR DESCRIPTION
In playing some more with Swoole task workers, I discovered that any
listeners you provide MUST be serializable - which poses a problem for
listeners that compose things such as HTTP clients, database adapters,
etc.

This patch:

- Adds a `Psr\Container\ContainerInterface $container` argument to
  `TaskInterface::__invoke()`.
- Modifies `TaskWorker` to compose the PSR-11 container, and pass it to
  tasks as it invokes them.
- Adds `ServiceBasedTask`, which accepts a service name and payload
  arguments to its constructor. When invoked, it will pull the service
  from the container. If the service is a `DeferredServiceListener`, it
  will pull the listener from that instance and use that. It invokes the
  service.
- Adds `DeferredServiceListener`, which creates a ServiceBasedTask with
  the service name passed to its constructor, and defines a
  `getListener()` method for getting the actual listener to use when
  handling the task.
- Adds `DeferredServiceListenerDelegator`, which creates a
  `DeferredServiceListener` using the service name and the result of
  calling the delegator's factory argument.

What this means is that users can assign the
`DeferredServiceListenerDelegator` as a delegator factory on listeners
that should defer execution to the Swoole task workers. This will be
safer than the `DeferredListenerDelegator` in almost every case.

Since this patch changes the signature of an interface method, I'm declaring it a new major version feature.
